### PR TITLE
Fix issue where passing a string 'constructor' would cause an exception

### DIFF
--- a/src/HashArray.js
+++ b/src/HashArray.js
@@ -38,7 +38,7 @@ var HashArray = JClass._extend({
       key = this.keyFields[key];
       var inst = this.objectAt(obj, key);
       if (inst) {
-        if (this._map[inst]) {
+        if (this.has(inst)) {
           if (this.options.ignoreDuplicates)
             return;
           if (this._map[inst].indexOf(obj) != -1) {
@@ -209,7 +209,7 @@ var HashArray = JClass._extend({
           var item = items[j];
           for (var ix in this.keyFields) {
             var key2 = this.objectAt(item, this.keyFields[ix]);
-            if (key2 && this._map[key2]) {
+            if (key2 && this.has(key2)) {
               var ix = this._map[key2].indexOf(item);
               if (ix != -1) {
                 this._map[key2].splice(ix, 1);


### PR DESCRIPTION
Hi,

I'm making use of your library [`trie-search`](https://github.com/joshjung/trie-search) to search through a list of words. One of these words is `constructor`, which conflicts with Javascript's own `constructor` keyword.

https://github.com/joshjung/hash-array/blob/e7fd2d47f58207d1b4ab0b784ba0597e2b16bae7/src/HashArray.js#L44

At this point, `this._map[inst]` returns the constructor function (available by default on every object), which does not have a `indexOf` method on it (it is not an array as we would expect).

The submitted PR seems to fix this issue for me, however I'm unsure if anything else needs to be fixed.