### PR TITLE
Fix `.get('constructor')` crash.

### DIFF
--- a/src/HashArray.js
+++ b/src/HashArray.js
@@ -131,6 +131,8 @@ var HashArray = JClass._extend({
   // Retrieval
   //-----------------------------------
   get: function(key) {
+    if (!this.has(key))
+      return;
     return (!(this._map[key] instanceof Array) || this._map[key].length != 1) ? this._map[key] : this._map[key][0];
   },
   getAll: function(keys) {

--- a/test/hashArrayTest.js
+++ b/test/hashArrayTest.js
@@ -48,6 +48,10 @@ describe('HashArray', function() {
 		it('Should map "whatever" to that item.', function() {
 			assert.equal(ha.get('whatever'), item);
 		});
+
+		it('Should not crash on the reserved keyword "constructor".', function() {
+			assert.equal(ha.get('constructo'), undefined);
+		});
     
 		it('Should return true to a collides for a similar object.', function() {
 			assert.equal(ha.collides({key: 'whatever'}), true);


### PR DESCRIPTION
The `constructor` keyword exists on `_map`, and the `has()` function is
smart enough to ignore things that aren't in `hasOwnProperty()`. Checking
it first prevents returning the constructor function object from `get()`.

This is similar to: https://github.com/joshjung/hash-array/pull/2

Fixes https://github.com/joshjung/trie-search/issues/39